### PR TITLE
Queries in My page to use full list view instead of simplified columns

### DIFF
--- a/app/views/my/_my_custom_form.html.erb
+++ b/app/views/my/_my_custom_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_tag(updatemyquery_path(:type => formtype), :id => "block-form", :method => :post) do %>
+  <%= hidden_field_tag 'object', object %>
+  <%= hidden_field_tag 'dashboard_id', dashboard_id %>
   <div class="box tabular">
     <% if formtype == 'my_cust_query' %>
       <p><%= label_tag "custom_limit", l(:label_custom_query_limit)  %>

--- a/app/views/my/_my_queries_issue_list.html.erb
+++ b/app/views/my/_my_queries_issue_list.html.erb
@@ -17,7 +17,7 @@
     <h3>
       <%= "#{l(:label_query)} : " %><%= link_to "#{query.name}", issues_path( param_hash ) %> (<%= "#{query_issues_count}" %>)
     </h3>
-    <%= render :partial => 'issues/list_simple', :locals => { :issues => query_issues, 
+    <%= render :partial => 'issues/list', :locals => { :issues => query_issues, 
                                                               :@query => query, 
                                                               :query => query, 
                                                               :@issue_count_by_group => query_issue_count_by_group } %>

--- a/app/views/my/_my_queries_issue_list.html.erb
+++ b/app/views/my/_my_queries_issue_list.html.erb
@@ -2,6 +2,7 @@
    if !query.nil?
 
     query_issues_count = query.issue_count
+    query_issue_count_by_group = query.issue_count_by_group
     param_hash = query.project_id.nil? ? { :query_id => query_id } : { :project_id => query.project_id, :query_id => query_id }
 
     if query_limit.to_i > 0
@@ -16,7 +17,10 @@
     <h3>
       <%= "#{l(:label_query)} : " %><%= link_to "#{query.name}", issues_path( param_hash ) %> (<%= "#{query_issues_count}" %>)
     </h3>
-    <%= render :partial => 'issues/list_simple', :locals => { :issues => query_issues } %>
+    <%= render :partial => 'issues/list_simple', :locals => { :issues => query_issues, 
+                                                              :@query => query, 
+                                                              :query => query, 
+                                                              :@issue_count_by_group => query_issue_count_by_group } %>
   <% else %>
     <div>
       <%= "#{l(:label_query)} : " %><%= link_to "#{query.name}", issues_path( param_hash ) %> (<%= "#{query_issues_count}" %>)

--- a/app/views/my/blocks/_activities.html.erb
+++ b/app/views/my/blocks/_activities.html.erb
@@ -17,7 +17,7 @@
   <div id='myactivities'>
     <% if !my_activity.nil? && my_activity[:query_ids].any? %>
       <% my_activity[:query_ids].each do |queryid| %>
-        <%= render :partial => "my_page_activities", :locals => { :query_id => queryid,
+        <%= render :partial => "my/my_page_activities", :locals => { :query_id => queryid,
                 :query_limit => my_activity[:limit] } %>
         <hr>
       <% end -%>

--- a/app/views/my/blocks/_custom_query_issues_list.html.erb
+++ b/app/views/my/blocks/_custom_query_issues_list.html.erb
@@ -1,13 +1,22 @@
-<% my_cust_query = user.pref.my_cust_query
+<% dashboard = nil if params[:controller] != 'dashboards'
+
+  my_cust_query = dashboard.nil? ? user.pref.my_cust_query : dashboard.my_cust_query
+
   if !my_cust_query.nil? %>
-  <div class="contextual">
-    <% if !my_cust_query[:query_ids].nil? && my_cust_query[:query_ids].empty? && controller.action_name == 'page' %>
-      <%= link_to l(:label_select_query), myqueryform_path(:type => 'my_cust_query'), :remote => true, :class => 'icon icon-add' %>
-    <% elsif !my_cust_query[:query_ids].nil? && my_cust_query[:query_ids].any? && controller.action_name != 'page_layout' %>
-      <%= link_to l(:label_update_query), myqueryform_path(:type => 'my_cust_query'), :remote => true,
-      :id => 'update_link_my_cust_query', :class => 'icon icon-edit' %>
-    <% end %>
-  </div>
+  <% if dashboard.nil? || dashboard.manage_layout?(user, "dashboards") %>
+    <div class="contextual">
+      <% if !my_cust_query[:query_ids].nil? && my_cust_query[:query_ids].empty? && controller.action_name == 'page' %>
+        <%= link_to l(:label_select_query),
+          myqueryform_path(:type => 'my_cust_query', :object => dashboard ? 'dashboard' : 'user',
+          :dashboard_id => dashboard ? dashboard.id : 0), :remote => true, :class => 'icon icon-add' %>
+      <% elsif !my_cust_query[:query_ids].nil? && my_cust_query[:query_ids].any? && controller.action_name != 'page_layout' %>
+        <%= link_to l(:label_update_query),
+        myqueryform_path(:type => 'my_cust_query', :object => dashboard ? 'dashboard' : 'user',
+          :dashboard_id => dashboard ? dashboard.id : 0), :remote => true,
+        :id => 'update_link_my_cust_query', :class => 'icon icon-edit' %>
+      <% end %>
+    </div>
+  <% end %>
   <% if (!my_cust_query[:query_ids].nil? && my_cust_query[:query_ids].empty?) || controller.action_name == 'page_layout' %>
     <h3><%= l(:label_my_custom_queries) %></h3>
   <% end %>
@@ -18,7 +27,7 @@
   <div id='mycustomquery'>
     <% if !my_cust_query.nil? && !my_cust_query[:query_ids].nil? && my_cust_query[:query_ids].any? %>
       <% my_cust_query[:query_ids].each do |queryid| %>
-        <%= render :partial => "my_queries_issue_list", :locals => { :query_id => queryid,
+        <%= render :partial => "my/my_queries_issue_list", :locals => { :query_id => queryid,
                 :query_limit => my_cust_query[:limit] } %>
         <hr>
       <% end -%>

--- a/app/views/my/my_custom_form.js.erb
+++ b/app/views/my/my_custom_form.js.erb
@@ -1,11 +1,11 @@
 <% if @vartype == 'my_cust_query' %>
   $( '#myqueryedit').html('<%= escape_javascript( render :partial => 'my_custom_form', :locals => { :custum_query => @my_cust_query,
-        :queries => @visible_queries, :formtype => @vartype  }) %>');
+        :queries => @visible_queries, :formtype => @vartype, :object => @object, :dashboard_id => @dashboard && @dashboard.id || 0 }) %>');
   $( '#myqueryedit').show();
   $( '#mycustomquery').hide();
 <% else %>
   $( '#myactivityedit').html('<%= escape_javascript( render :partial => 'my_custom_form', :locals => { :custum_query => @my_cust_query,
-        :queries => @visible_queries, :formtype => @vartype }) %>');
+        :queries => @visible_queries, :formtype => @vartype, :object => @object, :dashboard_id => @dashboard && @dashboard.id || 0 }) %>');
   $( '#myactivityedit').show();
   $( '#myactivities').hide();
 <% end -%>

--- a/app/views/settings/_my_page_option_settings.html.erb
+++ b/app/views/settings/_my_page_option_settings.html.erb
@@ -1,6 +1,6 @@
 <p>
   <label><%= l(:label_my_activity_enable) %></label>
-  <%= check_box_tag 'settings[my_activity_enable]', 1, settings['my_activity_enable'] == "1" %>
+  <%= check_box_tag 'settings[my_activity_enable]', 1, @settings[:my_activity_enable] == "1" %>
   <br />
   <em><%= l(:em_my_activity_enable) %></em>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,19 +1,23 @@
 # English strings go here for Rails i18n
 en:
-  label_my_activity_enable: Enable Activity listing in MyPage.
-  em_my_activity_enable: Check this to enable Activity page listing in the users My Page. Some bugs persist in the core Redmine activity fetcher.
+  activities: Activity
+  custom_query_issues_list: Issue lists from my queries
+  my_custom_queries: My queries
 
-  label_select_query: Select Queries
-  label_update_query: Update Query Selection
-  label_my_custom_queries: Custom Queries
-  label_select_activities: Select Activities
-  label_update_activities: Update Activity Selection
+  label_my_activity_enable: Enable activity listing in My page
+  em_my_activity_enable: Check this to enable Activity page listing in the users My page. Some bugs persist in the core Redmine activity fetcher.
+
+  label_select_query: Select a query
+  label_update_query: Update query selection
+  label_my_custom_queries: Custom query
+  label_select_activities: Select activities
+  label_update_activities: Update activity selection
   label_my_activities: Activity
 
-  label_activity_not_enabled: Activity Listing in My Page is not enabled.
+  label_activity_not_enabled: Activity listing in My page is not enabled.
 
-  label_custom_queries: Select Query
-  label_custom_query_limit: Limit Issue List
+  label_custom_queries: Select query
+  label_custom_query_limit: Limit issue list to
 
-  label_landing_page: Default Page after login
+  label_landing_page: Default page after login
   label_default_my_page: Pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,5 @@
 # English strings go here for Rails i18n
 en:
-  activities: Activity
-  custom_query_issues_list: Issue lists from my queries
-  my_custom_queries: My queries
-
   label_my_activity_enable: Enable activity listing in My page
   em_my_activity_enable: Check this to enable Activity page listing in the users My page. Some bugs persist in the core Redmine activity fetcher.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,19 +1,23 @@
 # English strings go here for Rails i18n
 en:
-  label_my_activity_enable: Enable activity listing in My page
-  em_my_activity_enable: Check this to enable Activity page listing in the users My page. Some bugs persist in the core Redmine activity fetcher.
+  activities: Activity
+  custom_query_issues_list: Issue lists from my queries
+  my_custom_queries: My queries
 
-  label_select_query: Select a query
-  label_update_query: Update query selection
-  label_my_custom_queries: Custom query
-  label_select_activities: Select activities
-  label_update_activities: Update activity selection
+  label_my_activity_enable: Enable Activity listing in MyPage.
+  em_my_activity_enable: Check this to enable Activity page listing in the users My Page. Some bugs persist in the core Redmine activity fetcher.
+
+  label_select_query: Select Queries
+  label_update_query: Update Query Selection
+  label_my_custom_queries: Custom Queries
+  label_select_activities: Select Activities
+  label_update_activities: Update Activity Selection
   label_my_activities: Activity
 
-  label_activity_not_enabled: Activity listing in My page is not enabled.
+  label_activity_not_enabled: Activity Listing in My Page is not enabled.
 
-  label_custom_queries: Select query
-  label_custom_query_limit: Limit issue list to
+  label_custom_queries: Select Query
+  label_custom_query_limit: Limit Issue List
 
-  label_landing_page: Default page after login
+  label_landing_page: Default Page after login
   label_default_my_page: Pages

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,23 +1,19 @@
 # French strings go here for Rails i18n
 fr:
-  activities: Activit√©
-  custom_query_issues_list: Listes de demandes de mes rapports
-  my_custom_queries: Mes rapports
+  label_my_activity_enable: Activer l'affichage des activitÈs dans Ma page
+  em_my_activity_enable: Cocher cette option pour activer l'affichage des activitÈs dans la page personnalisÈ des utilisateurs. Des bugs sont encore prÈsents dans cette fonctionnalitÈ.
 
-  label_my_activity_enable: Activer l'affichage des activit√©s dans Ma page
-  em_my_activity_enable: Cocher cette option pour activer l'affichage des activit√©s dans la page personnalis√© des utilisateurs. Des bugs sont encore pr√©sents dans cette fonctionnalit√©.
-
-  label_select_query: S√©lectionner un rapport
+  label_select_query: SÈlectionner un rapport
   label_update_query: Changer de rapport
-  label_my_custom_queries: Rapport personnalis√©
-  label_select_activities: S√©lectionner un type d'activit√©
-  label_update_activities: Changer de type d'activit√©
-  label_my_activities: Activit√©
+  label_my_custom_queries: Rapport personnalisÈ
+  label_select_activities: SÈlectionner un type d'activitÈ
+  label_update_activities: Changer de type d'activitÈ
+  label_my_activities: ActivitÈ
 
-  label_activity_not_enabled: L'affichage des activit√©s dans Ma page n'est pas activ√©.
+  label_activity_not_enabled: L'affichage des activitÈs dans Ma page n'est pas activÈ.
 
-  label_custom_queries: S√©lectionner un rapport
-  label_custom_query_limit: Limiter la liste des demandes √†
+  label_custom_queries: SÈlectionner un rapport
+  label_custom_query_limit: Limiter la liste des demandes ‡
 
-  label_landing_page: Page par d√©faut apr√®s la connexion
+  label_landing_page: Page par dÈfaut aprËs la connexion
   label_default_my_page: Pages

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,23 @@
+# French strings go here for Rails i18n
+fr:
+  activities: Activité
+  custom_query_issues_list: Listes de demandes de mes rapports
+  my_custom_queries: Mes rapports
+
+  label_my_activity_enable: Activer l'affichage des activités dans Ma page
+  em_my_activity_enable: Cocher cette option pour activer l'affichage des activités dans la page personnalisé des utilisateurs. Des bugs sont encore présents dans cette fonctionnalité.
+
+  label_select_query: Sélectionner un rapport
+  label_update_query: Changer de rapport
+  label_my_custom_queries: Rapport personnalisé
+  label_select_activities: Sélectionner un type d'activité
+  label_update_activities: Changer de type d'activité
+  label_my_activities: Activité
+
+  label_activity_not_enabled: L'affichage des activités dans Ma page n'est pas activé.
+
+  label_custom_queries: Sélectionner un rapport
+  label_custom_query_limit: Limiter la liste des demandes à
+
+  label_landing_page: Page par défaut après la connexion
+  label_default_my_page: Pages

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,9 +1,5 @@
 # Russian strings go here for Rails i18n
 ru:
-  activities: Активности
-  custom_query_issues_list: Список задач моих запросов
-  my_custom_queries: Мои сохранённые запросы
-
   label_my_activity_enable: Включить отчет об активностях на Моей странице.
   em_my_activity_enable: Поставьте галочку чтобы включить отчет об активностях на "Моя страница" всех пользователей. Есть некоторые баги, связанные с ядром Redmine.
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -17,3 +17,8 @@ ru:
 
   label_landing_page: Страница по умолчанию после логина
   label_default_my_page: Страницы
+    
+  custom_query_issues_list: Задачи из сохраненного запроса
+  activities: Активности
+  my_custom_queries: Мои сохраненные запросы
+

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,5 +1,9 @@
 # Russian strings go here for Rails i18n
 ru:
+  activities: Активности
+  custom_query_issues_list: Список задач моих запросов
+  my_custom_queries: Мои сохранённые запросы
+
   label_my_activity_enable: Включить отчет об активностях на Моей странице.
   em_my_activity_enable: Поставьте галочку чтобы включить отчет об активностях на "Моя страница" всех пользователей. Есть некоторые баги, связанные с ядром Redmine.
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,19 @@
+# Russian strings go here for Rails i18n
+ru:
+  label_my_activity_enable: Включить отчет об активностях на Моей странице.
+  em_my_activity_enable: Поставьте галочку чтобы включить отчет об активностях на "Моя страница" всех пользователей. Есть некоторые баги, связанные с ядром Redmine.
+
+  label_select_query: Выбрать запросы
+  label_update_query: Обновить выбор запроса
+  label_my_custom_queries: Сохраненные запросы
+  label_select_activities: Выберите активности
+  label_update_activities: Обновить выбор активностей
+  label_my_activities: Активности
+
+  label_activity_not_enabled: Отчет об активности выключен
+
+  label_custom_queries: Выбрать запрос
+  label_custom_query_limit: Ограничение для показа
+
+  label_landing_page: Страница по умолчанию после логина
+  label_default_my_page: Страницы

--- a/init.rb
+++ b/init.rb
@@ -5,14 +5,14 @@ require 'my_page_patches/user_preference_patch'
 require 'my_page_patches/welcome_controller_patch'
 
 ActionDispatch::Callbacks.to_prepare do
-  require_dependency 'hooks/redmine_my_page_hook'
+  require_dependency 'my_page_patches/redmine_my_page_hook'
 end
 
 Redmine::Plugin.register :redmine_my_page do
   name 'My Page Customization'
   author 'Rupesh J'
   description 'Adds additional options to the My Page of users.\nCustom Queries and Activities ( filtered ) will be shown in a single page.'
-  version '0.1.7'
+  version '0.1.9'
 
   settings :default => { 'my_activity_enable' => false },
             :partial => 'settings/my_page_option_settings'

--- a/lib/hooks/redmine_my_page_hook.rb
+++ b/lib/hooks/redmine_my_page_hook.rb
@@ -1,6 +1,16 @@
 module Hooks
   class RedmineMyPageHook < Redmine::Hook::ViewListener
+
     def view_my_account_preferences(context={})
+      user_preferences_hook(context)
+    end
+
+    def view_users_form_preferences(context={})
+      user_preferences_hook(context)
+    end
+
+    private
+    def user_preferences_hook(context={})
       user  = context[:user]
       f     = context[:form]
       s     = ''
@@ -27,5 +37,6 @@ module Hooks
 
       return s.html_safe
     end
+
   end
 end

--- a/lib/hooks/redmine_my_page_hook.rb
+++ b/lib/hooks/redmine_my_page_hook.rb
@@ -1,42 +1,44 @@
-module Hooks
-  class RedmineMyPageHook < Redmine::Hook::ViewListener
-
-    def view_my_account_preferences(context={})
-      user_preferences_hook(context)
+module MyPage
+  module Hooks
+    class RedmineMyPageHook < Redmine::Hook::ViewListener
+  
+      def view_my_account_preferences(context={})
+        user_preferences_hook(context)
+      end
+  
+      def view_users_form_preferences(context={})
+        user_preferences_hook(context)
+      end
+  
+      private
+      def user_preferences_hook(context={})
+        user  = context[:user]
+        f     = context[:form]
+        s     = ''
+  
+        # List all the landing pages after login.
+        # 1) Issue List of a project
+        # 2) Custom Query Issue List.
+        # 3) My Page
+        projects = Project.visible.includes(:enabled_modules).
+            select { |p| p if p.module_enabled?("issue_tracking") }
+  
+        selection_options = [[l(:label_default_my_page), [ [l(:label_my_page), "my_page"]] + projects.
+                      map { |p| ["Overview - #{p.name}", "o-#{p.id}" ] } ]]
+        selection_options += [[ 'Issue List of Project', projects.
+                      map { |p| ["#{p.name}", "p-#{p.id}" ] }]]
+        selection_options += [[ 'Custom Query', IssueQuery.where( :user_id => User.current.id, :project_id => Project.visible.pluck(:id) ).
+                      pluck(:name,:id).map { |name,id| ["#{name}", "q-#{id}" ] }]]
+  
+        s << "<p>"
+        s << label_tag( "pref_landing_page", l(:label_landing_page) )
+        s << select_tag( "pref[landing_page]", grouped_options_for_select(selection_options,
+                      selected_key = user.pref.landing_page ), :id => 'pref_landing_page', :include_blank => true )
+        s << "</p>"
+  
+        return s.html_safe
+      end
+  
     end
-
-    def view_users_form_preferences(context={})
-      user_preferences_hook(context)
-    end
-
-    private
-    def user_preferences_hook(context={})
-      user  = context[:user]
-      f     = context[:form]
-      s     = ''
-
-      # List all the landing pages after login.
-      # 1) Issue List of a project
-      # 2) Custom Query Issue List.
-      # 3) My Page
-      projects = Project.visible.includes(:enabled_modules).
-          select { |p| p if p.module_enabled?("issue_tracking") }
-
-      selection_options = [[l(:label_default_my_page), [ [l(:label_my_page), "my_page"]] + projects.
-                    map { |p| ["Overview - #{p.name}", "o-#{p.id}" ] } ]]
-      selection_options += [[ 'Issue List of Project', projects.
-                    map { |p| ["#{p.name}", "p-#{p.id}" ] }]]
-      selection_options += [[ 'Custom Query', IssueQuery.where( :user_id => User.current.id, :project_id => Project.visible.pluck(:id) ).
-                    pluck(:name,:id).map { |name,id| ["#{name}", "q-#{id}" ] }]]
-
-      s << "<p>"
-      s << label_tag( "pref_landing_page", l(:label_landing_page) )
-      s << select_tag( "pref[landing_page]", grouped_options_for_select(selection_options,
-                    selected_key = user.pref.landing_page ), :id => 'pref_landing_page', :include_blank => true )
-      s << "</p>"
-
-      return s.html_safe
-    end
-
   end
 end

--- a/lib/hooks/redmine_my_page_hook.rb
+++ b/lib/hooks/redmine_my_page_hook.rb
@@ -1,44 +1,42 @@
-module MyPage
-  module Hooks
-    class RedmineMyPageHook < Redmine::Hook::ViewListener
-  
-      def view_my_account_preferences(context={})
-        user_preferences_hook(context)
-      end
-  
-      def view_users_form_preferences(context={})
-        user_preferences_hook(context)
-      end
-  
-      private
-      def user_preferences_hook(context={})
-        user  = context[:user]
-        f     = context[:form]
-        s     = ''
-  
-        # List all the landing pages after login.
-        # 1) Issue List of a project
-        # 2) Custom Query Issue List.
-        # 3) My Page
-        projects = Project.visible.includes(:enabled_modules).
-            select { |p| p if p.module_enabled?("issue_tracking") }
-  
-        selection_options = [[l(:label_default_my_page), [ [l(:label_my_page), "my_page"]] + projects.
-                      map { |p| ["Overview - #{p.name}", "o-#{p.id}" ] } ]]
-        selection_options += [[ 'Issue List of Project', projects.
-                      map { |p| ["#{p.name}", "p-#{p.id}" ] }]]
-        selection_options += [[ 'Custom Query', IssueQuery.where( :user_id => User.current.id, :project_id => Project.visible.pluck(:id) ).
-                      pluck(:name,:id).map { |name,id| ["#{name}", "q-#{id}" ] }]]
-  
-        s << "<p>"
-        s << label_tag( "pref_landing_page", l(:label_landing_page) )
-        s << select_tag( "pref[landing_page]", grouped_options_for_select(selection_options,
-                      selected_key = user.pref.landing_page ), :id => 'pref_landing_page', :include_blank => true )
-        s << "</p>"
-  
-        return s.html_safe
-      end
-  
+module Hooks
+  class RedmineMyPageHook < Redmine::Hook::ViewListener
+
+    def view_my_account_preferences(context={})
+      user_preferences_hook(context)
     end
+
+    def view_users_form_preferences(context={})
+      user_preferences_hook(context)
+    end
+
+    private
+    def user_preferences_hook(context={})
+      user  = context[:user]
+      f     = context[:form]
+      s     = ''
+
+      # List all the landing pages after login.
+      # 1) Issue List of a project
+      # 2) Custom Query Issue List.
+      # 3) My Page
+      projects = Project.visible.includes(:enabled_modules).
+          select { |p| p if p.module_enabled?("issue_tracking") }
+
+      selection_options = [[l(:label_default_my_page), [ [l(:label_my_page), "my_page"]] + projects.
+                    map { |p| ["Overview - #{p.name}", "o-#{p.id}" ] } ]]
+      selection_options += [[ 'Issue List of Project', projects.
+                    map { |p| ["#{p.name}", "p-#{p.id}" ] }]]
+      selection_options += [[ 'Custom Query', IssueQuery.where( :user_id => User.current.id, :project_id => Project.visible.pluck(:id) ).
+                    pluck(:name,:id).map { |name,id| ["#{name}", "q-#{id}" ] }]]
+
+      s << "<p>"
+      s << label_tag( "pref_landing_page", l(:label_landing_page) )
+      s << select_tag( "pref[landing_page]", grouped_options_for_select(selection_options,
+                    selected_key = user.pref.landing_page ), :id => 'pref_landing_page', :include_blank => true )
+      s << "</p>"
+
+      return s.html_safe
+    end
+
   end
 end

--- a/lib/my_page_patches/my_controller_patch.rb
+++ b/lib/my_page_patches/my_controller_patch.rb
@@ -21,40 +21,57 @@ module MyPagePatches
     module InstanceMethods
       def my_custom_form
         @user = User.current
+        @object = params[:object]
         @pref = @user.pref
 
-        visible_queries_array = if IssueQuery.respond_to? (:esi_visible_queries)
-          IssueQuery.esi_visible_queries.
-            order("#{Project.table_name}.name ASC", "#{Query.table_name}.name ASC").
-            pluck(:name, :id, "projects.name").to_a
-        else
-          IssueQuery.visible.
-            order("#{Project.table_name}.name ASC", "#{Query.table_name}.name ASC").
-            pluck(:name, :id, "projects.name").to_a
+        if @object == 'dashboard'
+          @dashboard = Dashboard.find_by_id(params[:dashboard_id])
+          deny_access unless @dashboard && @dashboard.manage_layout?(@user)
         end
-        @visible_queries = visible_queries_array.collect { |name, id, projectname| ["#{projectname.blank? ? "" : projectname + " - "}#{name}", id ] }
-
         if params["type"].present? && params["type"] == 'my_cust_query'
           @vartype = "my_cust_query"
-          @my_cust_query = @pref.my_cust_query
+          @my_cust_query = @object == 'dashboard' ? @dashboard.my_cust_query : @pref.my_cust_query
         else
           @vartype = "my_activity"
-          @my_cust_query = @pref.my_activity
+          @my_cust_query = @object == 'dashboard' ? @dashboard.my_activity : @pref.my_activity
         end
+
+        visible_queries_array = IssueQuery.visible.
+            order("#{Project.table_name}.name ASC", "#{Query.table_name}.name ASC").
+            pluck(:name, :id, "projects.name").to_a
+
+        @visible_queries = visible_queries_array.collect { |name, id, projectname| ["#{projectname.blank? ? "" : projectname + " - "}#{name}", id ] }
       end
 
       def update_queries
-        if params["my_cust_query"].present?
-          @user_pref              = User.current.pref.my_cust_query
-          @user_pref[:limit]      = params["my_cust_query"]["limit"] || 10
-          @user_pref[:query_ids]  = params["my_cust_query"]["query_ids"].any? ? params["my_cust_query"]["query_ids"].collect { |i| i.to_i } : []
-          User.current.pref.save
-        elsif params["my_activity"].present?
-          @user_pref              = User.current.pref.my_activity
-          @user_pref[:query_ids]  = params["my_activity"]["query_ids"].any? ? params["my_activity"]["query_ids"].collect { |i| i.to_i } : []
-          User.current.pref.save
+        @object = params[:object]
+        if @object == 'dashboard'
+          @dashboard              = Dashboard.find_by_id(params[:dashboard_id])
+          deny_access unless @dashboard && @dashboard.manage_layout?(User.current)
+          if params["my_cust_query"].present?
+            dashboard_pref              = @dashboard.my_cust_query
+            dashboard_pref[:limit]      = params["my_cust_query"]["limit"] || 10
+            dashboard_pref[:query_ids]  = params["my_cust_query"]["query_ids"].any? ? params["my_cust_query"]["query_ids"].collect { |i| i.to_i } : []
+            @dashboard.save
+          elsif params["my_activity"].present?
+            dashboard_pref              = @dashboard.my_activity
+            dashboard_pref[:query_ids]  = params["my_activity"]["query_ids"].any? ? params["my_activity"]["query_ids"].collect { |i| i.to_i } : []
+            @dashboard.save
+          end
+          redirect_to dashboards_path( :id => @dashboard.id )
+        else
+          if params["my_cust_query"].present?
+            @user_pref              = User.current.pref.my_cust_query
+            @user_pref[:limit]      = params["my_cust_query"]["limit"] || 10
+            @user_pref[:query_ids]  = params["my_cust_query"]["query_ids"].any? ? params["my_cust_query"]["query_ids"].collect { |i| i.to_i } : []
+            User.current.pref.save
+          elsif params["my_activity"].present?
+            @user_pref              = User.current.pref.my_activity
+            @user_pref[:query_ids]  = params["my_activity"]["query_ids"].any? ? params["my_activity"]["query_ids"].collect { |i| i.to_i } : []
+            User.current.pref.save
+          end
+          redirect_to my_page_path
         end
-        redirect_to my_page_path
       end
     end
   end

--- a/lib/my_page_patches/my_controller_patch.rb
+++ b/lib/my_page_patches/my_controller_patch.rb
@@ -8,6 +8,8 @@ module MyPagePatches
 
       base.class_eval do
         unloadable
+        helper :queries
+        base.send(:include, QueriesHelper)
         helper :sort
         base.send(:include, SortHelper)
       end

--- a/lib/my_page_patches/redmine_my_page_hook.rb
+++ b/lib/my_page_patches/redmine_my_page_hook.rb
@@ -1,16 +1,14 @@
-module Hooks
+module MyPagePatches
   class RedmineMyPageHook < Redmine::Hook::ViewListener
+    def view_users_form_preferences(context={})
+      user_langing_page_options(context)
+    end
 
     def view_my_account_preferences(context={})
-      user_preferences_hook(context)
+      user_langing_page_options(context)
     end
 
-    def view_users_form_preferences(context={})
-      user_preferences_hook(context)
-    end
-
-    private
-    def user_preferences_hook(context={})
+    def user_langing_page_options(context)
       user  = context[:user]
       f     = context[:form]
       s     = ''
@@ -37,6 +35,5 @@ module Hooks
 
       return s.html_safe
     end
-
   end
 end


### PR DESCRIPTION
This pull request is about using the standard query view instead of the simplified one, so that queries chosen in the My queries block can display all columns as chosen for the query, rather than only the Id, Tracker and Title columns.

Note that I am not familiar with github and branches and pull requests, and I had to move all my personal changes to a branch before doing this pull request, and consequently the history might look a bit messy.
Changes involve only 2 lines in app/views/my/_my_queries_issue_list.html.erb and 2 lines in lib/my_page_patches/my_controller_patch.rb.
